### PR TITLE
internal/changelog: Fix breaking change kind label

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -133,7 +133,7 @@ func (g *Generator) getPRKind(pr *github.PullRequest) string {
 			return "new_feature"
 		case "kind/bug":
 			return "bug_fix"
-		case "kind/breaking-change":
+		case "kind/breaking_change":
 			return "breaking_change"
 		case "kind/documentation":
 			return "documentation"

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -90,6 +90,7 @@ func TestGenerateChangelog(t *testing.T) {
 			issuesForSearch: []*github.Issue{
 				{Number: github.Ptr(42)},
 				{Number: github.Ptr(43)},
+				{Number: github.Ptr(44)},
 			},
 			pullRequests: []*github.PullRequest{
 				{
@@ -108,6 +109,14 @@ func TestGenerateChangelog(t *testing.T) {
 						Name: github.Ptr("kind/bug"),
 					}},
 				},
+				{
+					Number: github.Ptr(44),
+					Title:  github.Ptr("Remove old feature"),
+					Body:   github.Ptr("```release-note\\nRemoved old feature\\n```"),
+					Labels: []*github.Label{{
+						Name: github.Ptr("kind/breaking_change"),
+					}},
+				},
 			},
 			expectedChangelog: `
 ## 🚀 Features
@@ -117,7 +126,11 @@ func TestGenerateChangelog(t *testing.T) {
 ## 🐛 Bug Fixes
 
 - Fix bug (#43)
-			`,
+
+## 💥 Breaking Changes
+
+- Remove old feature (#44)
+`,
 			expectError: false,
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Fix the generator logic that was referencing the wrong breaking change kind type in the getPRKind method. Add a unit test case that validates incorrect changelog content was being generated before this change.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix kind/breaking_change label selection.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
